### PR TITLE
fix Find() : now sets Limit in returned ItemList

### DIFF
--- a/mongo.go
+++ b/mongo.go
@@ -221,7 +221,7 @@ func (m Handler) Find(ctx context.Context, lookup *resource.Lookup, offset, limi
 	iter := query.Iter()
 	// Total is set to -1 because we have no easy way with Mongodb to to compute this value
 	// without performing two requests.
-	list := &resource.ItemList{Total: -1, Items: []*resource.Item{}}
+	list := &resource.ItemList{Total: -1, Limit: limit, Items: []*resource.Item{}}
 	for iter.Next(&mItem) {
 		// Check if context is still ok before to continue
 		if err = ctx.Err(); err != nil {


### PR DESCRIPTION
The limit parameter was not returned back in ItemList, so itemlist.Limit was still 0.
Therefore a custom formatter could not use this information.