### PR TITLE
id: add ObjectID.Validate passthue for already casted ids

### DIFF
--- a/id.go
+++ b/id.go
@@ -36,6 +36,10 @@ type ObjectID struct{}
 
 // Validate implements FieldValidator interface
 func (v ObjectID) Validate(value interface{}) (interface{}, error) {
+	_, ok := value.(bson.ObjectId)
+	if ok {
+		return value, nil
+	}
 	s, ok := value.(string)
 	if !ok {
 		return nil, errors.New("invalid object id")


### PR DESCRIPTION
When creating optional sub-resource:


    clients := index.Bind("clients", client, dbClients, resource.Conf{AllowedModes: resource.ReadWrite})
    services := index.Bind("services", service, dbServices, resource.Conf{AllowedModes: resource.ReadWrite})
    clients.Bind("services", "client", service, dbServices, resource.Conf{AllowedModes: resource.ReadWrite})

One can add resources via these two endpoints:
`/services`
`/clients/[id]/services`

But in the second case `rest-layer-mongo` complains with `invalid object id`. Upon investigation I found that argument for `ObjectID.Validate` already is `bson.ObjectID` type. So added a passthu. 
This may be very well problem in other part of the system, but it worked for me.

The resource structure above worked fine with Memory store.
