### PR TITLE
Fix Total calculation

### DIFF
--- a/mongo.go
+++ b/mongo.go
@@ -257,12 +257,17 @@ func (m Handler) Find(ctx context.Context, q *query.Query) (*resource.ItemList, 
 	if err := iter.Close(); err != nil {
 		return nil, err
 	}
-	// If the number of returned elements is lower than requested limit, or not
+	// If the number of returned elements is lower than requested limit, or no
 	// limit is requested, we can deduce the total number of element for free.
 	if limit < 0 || len(list.Items) < limit {
-		list.Total = len(list.Items)
 		if q.Window != nil && q.Window.Offset > 0 {
-			list.Total += q.Window.Offset
+			if len(list.Items) > 0 {
+				list.Total = q.Window.Offset + len(list.Items)
+			}
+			// If there are no items returned when Offset > 0, we may be out-of-bounds,
+			// and therefore cannot deduce the total count of items.
+		} else {
+			list.Total = len(list.Items)
 		}
 	}
 	return list, err

--- a/mongo_test.go
+++ b/mongo_test.go
@@ -209,6 +209,24 @@ func TestFind(t *testing.T) {
 		assert.Len(t, l.Items, 0)
 	}
 
+	l, err = h.Find(ctx, &query.Query{Window: &query.Window{Limit: -1, Offset: 2}})
+	if assert.NoError(t, err) {
+		assert.Equal(t, 5, l.Total)
+		assert.Len(t, l.Items, 3)
+	}
+
+	l, err = h.Find(ctx, &query.Query{Window: &query.Window{Limit: -1, Offset: 5}})
+	if assert.NoError(t, err) {
+		assert.Equal(t, -1, l.Total)
+		assert.Len(t, l.Items, 0)
+	}
+
+	l, err = h.Find(ctx, &query.Query{Window: &query.Window{Limit: -1, Offset: 6}})
+	if assert.NoError(t, err) {
+		assert.Equal(t, -1, l.Total)
+		assert.Len(t, l.Items, 0)
+	}
+
 	q, err := query.New("", `{name:"c"}`, "", query.Page(1, 1, 0))
 	if assert.NoError(t, err) {
 		l, err = h.Find(ctx, q)


### PR DESCRIPTION
When `Offset` is set, check if any items are returned. If there are no items returned, we are out of range, and we can't guess the `Total` anymore. In this case we leave the default value of `-1` and let `rest-layer` get it using the `Count` function when requested explicitly with `ForceTotalMode` or `?total=1`.

Message modified by @smyrman